### PR TITLE
Update test artifact to use Newtonsoft.Json 12

### DIFF
--- a/tests/dotnet/Apache.OpenWhisk.Tests.Dotnet/Apache.OpenWhisk.Tests.Dotnet.csproj
+++ b/tests/dotnet/Apache.OpenWhisk.Tests.Dotnet/Apache.OpenWhisk.Tests.Dotnet.csproj
@@ -21,7 +21,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+      <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This updates the test artifact to match the runtime version of Newtonsoft.Json to 12.x