### PR TITLE
Prepare CHANGELOG for 1.14 release.

### DIFF
--- a/core/dotnet2.2/CHANGELOG.md
+++ b/core/dotnet2.2/CHANGELOG.md
@@ -20,11 +20,7 @@
 # .NET Core 2.2 OpenWhisk Runtime Container
 
 
-## 1.13
-Changes:
-- Initial release
-
-## Release TBD
+## 1.14
 Changes:
 - Support for async methods. Example:
 
@@ -35,3 +31,7 @@ Changes:
             return (args);
         }
 ```
+
+## 1.13
+Changes:
+- Initial release

--- a/core/dotnet3.1/CHANGELOG.md
+++ b/core/dotnet3.1/CHANGELOG.md
@@ -20,7 +20,7 @@
 # .NET Core 3.1 OpenWhisk Runtime Container
 
 
-## Release TBD
+## 1.14
 Changes:
 - Initial release
 - Support for async methods. Example:


### PR DESCRIPTION
1. Put in 1.14 version number
2. Reorder 2.2 changelog to put newest on top per runtimes convention