### PR TITLE
Get latest security updates with every build.

### DIFF
--- a/core/dotnet2.2/CHANGELOG.md
+++ b/core/dotnet2.2/CHANGELOG.md
@@ -20,6 +20,11 @@
 # .NET Core 2.2 OpenWhisk Runtime Container
 
 
+## 1.15 (next release)
+Changes:
+- Get the latest security fixes (apk upgrade) with every build.
+
+
 ## 1.14
 Changes:
 - Support for async methods. Example:

--- a/core/dotnet2.2/Dockerfile
+++ b/core/dotnet2.2/Dockerfile
@@ -29,6 +29,12 @@ WORKDIR /app/Apache.OpenWhisk.Runtime.Dotnet.Minimal
 RUN dotnet publish -c Release -r alpine.3.9-x64 -o out
 
 FROM mcr.microsoft.com/dotnet/core/runtime:2.2-alpine AS runtime
+
+# Get the latest security fixes in case the base image does not contain them already.
+RUN apk update \
+    && apk upgrade \
+    && rm -f /var/cache/apk/*
+
 WORKDIR /app
 COPY --from=build /app/Apache.OpenWhisk.Runtime.Dotnet.Minimal/out ./
 ENV ASPNETCORE_URLS http://+:8080

--- a/core/dotnet3.1/CHANGELOG.md
+++ b/core/dotnet3.1/CHANGELOG.md
@@ -20,6 +20,11 @@
 # .NET Core 3.1 OpenWhisk Runtime Container
 
 
+## 1.15 (next release)
+Changes:
+- Get the latest security fixes (apk upgrade) with every build.
+
+
 ## 1.14
 Changes:
 - Initial release

--- a/core/dotnet3.1/Dockerfile
+++ b/core/dotnet3.1/Dockerfile
@@ -29,6 +29,12 @@ WORKDIR /app/Apache.OpenWhisk.Runtime.Dotnet.Minimal
 RUN dotnet publish -c Release -r linux-musl-x64 -o out
 
 FROM mcr.microsoft.com/dotnet/core/runtime:3.1-alpine AS runtime
+
+# Get the latest security fixes in case the base image does not contain them already.
+RUN apk update \
+    && apk upgrade \
+    && rm -f /var/cache/apk/*
+
 WORKDIR /app
 COPY --from=build /app/Apache.OpenWhisk.Runtime.Dotnet.Minimal/out ./
 ENV ASPNETCORE_URLS http://+:8080


### PR DESCRIPTION
  - Add 'apk upgrade' to the image builds to include security fixes with each build in case the used base image is not updated frequently.
    In case the base image is updated frequently, the 'apk upgrade' is a no operation. If not it will catch the security updates available since the last update of the base image.