### PR TITLE
Increased MaxRequestBodySize, so larger zip files can be uploaded

### DIFF
--- a/core/dotnet2.2/proxy/Apache.OpenWhisk.Runtime.Dotnet.Minimal/Program.cs
+++ b/core/dotnet2.2/proxy/Apache.OpenWhisk.Runtime.Dotnet.Minimal/Program.cs
@@ -32,6 +32,10 @@ namespace Apache.OpenWhisk.Runtime.Dotnet.Minimal
         
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
+                .UseKestrel(options =>
+                {
+                    options.Limits.MaxRequestBodySize = null;
+                })
                 .ConfigureLogging((hostingContext, logging) =>
                 {
                     logging.ClearProviders();

--- a/core/dotnet3.1/proxy/Apache.OpenWhisk.Runtime.Dotnet.Minimal/Program.cs
+++ b/core/dotnet3.1/proxy/Apache.OpenWhisk.Runtime.Dotnet.Minimal/Program.cs
@@ -32,6 +32,10 @@ namespace Apache.OpenWhisk.Runtime.Dotnet.Minimal
         
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
+                .UseKestrel(options =>
+                {
+                    options.Limits.MaxRequestBodySize = null;
+                })
                 .ConfigureLogging((hostingContext, logging) =>
                 {
                     logging.ClearProviders();

--- a/tests/src/test/scala/actionContainers/DotNet2_2ActionContainerTests.scala
+++ b/tests/src/test/scala/actionContainers/DotNet2_2ActionContainerTests.scala
@@ -23,6 +23,7 @@ import common.WskActorSystem
 import spray.json._
 import actionContainers.ActionContainer.withContainer
 import java.nio.file.Paths
+import java.lang.StringBuilder
 
 @RunWith(classOf[JUnitRunner])
 class DotNet2_2ActionContainerTests extends BasicActionRunnerTests with WskActorSystem {
@@ -98,6 +99,19 @@ class DotNet2_2ActionContainerTests extends BasicActionRunnerTests with WskActor
       case (o, e) =>
         (o + e).toLowerCase should include("exception")
     })
+  }
+
+  it should "support a large payload" in {
+    val (out, err) = withActionContainer() { c =>
+      val sb = new StringBuilder(18000000 + functionb64.length());
+      sb.append(functionb64);
+      for (i <- 0 to 18000000) {
+        sb.append(' ');
+      }
+      val (initCode, _) =
+        c.init(initPayload(sb.toString(), "Apache.OpenWhisk.Tests.Dotnet::Apache.OpenWhisk.Tests.Dotnet.Error::Main"))
+      initCode should be(200)
+    }
   }
 
   it should "support application errors" in {

--- a/tests/src/test/scala/actionContainers/DotNet2_2ActionContainerTests.scala
+++ b/tests/src/test/scala/actionContainers/DotNet2_2ActionContainerTests.scala
@@ -23,7 +23,6 @@ import common.WskActorSystem
 import spray.json._
 import actionContainers.ActionContainer.withContainer
 import java.nio.file.Paths
-import java.lang.StringBuilder
 
 @RunWith(classOf[JUnitRunner])
 class DotNet2_2ActionContainerTests extends BasicActionRunnerTests with WskActorSystem {
@@ -103,13 +102,9 @@ class DotNet2_2ActionContainerTests extends BasicActionRunnerTests with WskActor
 
   it should "support a large payload" in {
     val (out, err) = withActionContainer() { c =>
-      val sb = new StringBuilder(18000000 + functionb64.length());
-      sb.append(functionb64);
-      for (i <- 0 to 18000000) {
-        sb.append(' ');
-      }
+      val payload = functionb64 + (" " * 18000000)
       val (initCode, _) =
-        c.init(initPayload(sb.toString(), "Apache.OpenWhisk.Tests.Dotnet::Apache.OpenWhisk.Tests.Dotnet.Error::Main"))
+        c.init(initPayload(payload, "Apache.OpenWhisk.Tests.Dotnet::Apache.OpenWhisk.Tests.Dotnet.Error::Main"))
       initCode should be(200)
     }
   }

--- a/tests/src/test/scala/actionContainers/DotNet3_1ActionContainerTests.scala
+++ b/tests/src/test/scala/actionContainers/DotNet3_1ActionContainerTests.scala
@@ -23,6 +23,7 @@ import common.WskActorSystem
 import spray.json._
 import actionContainers.ActionContainer.withContainer
 import java.nio.file.Paths
+import java.lang.StringBuilder
 
 @RunWith(classOf[JUnitRunner])
 class DotNet3_1ActionContainerTests extends BasicActionRunnerTests with WskActorSystem {
@@ -98,6 +99,19 @@ class DotNet3_1ActionContainerTests extends BasicActionRunnerTests with WskActor
       case (o, e) =>
         (o + e).toLowerCase should include("exception")
     })
+  }
+
+  it should "support a large payload" in {
+    val (out, err) = withActionContainer() { c =>
+      val sb = new StringBuilder(18000000 + functionb64.length());
+      sb.append(functionb64);
+      for (i <- 0 to 18000000) {
+        sb.append(' ');
+      }
+      val (initCode, _) =
+        c.init(initPayload(sb.toString(), "Apache.OpenWhisk.Tests.Dotnet::Apache.OpenWhisk.Tests.Dotnet.Error::Main"))
+      initCode should be(200)
+    }
   }
 
   it should "support application errors" in {

--- a/tests/src/test/scala/actionContainers/DotNet3_1ActionContainerTests.scala
+++ b/tests/src/test/scala/actionContainers/DotNet3_1ActionContainerTests.scala
@@ -23,7 +23,6 @@ import common.WskActorSystem
 import spray.json._
 import actionContainers.ActionContainer.withContainer
 import java.nio.file.Paths
-import java.lang.StringBuilder
 
 @RunWith(classOf[JUnitRunner])
 class DotNet3_1ActionContainerTests extends BasicActionRunnerTests with WskActorSystem {
@@ -103,13 +102,9 @@ class DotNet3_1ActionContainerTests extends BasicActionRunnerTests with WskActor
 
   it should "support a large payload" in {
     val (out, err) = withActionContainer() { c =>
-      val sb = new StringBuilder(18000000 + functionb64.length());
-      sb.append(functionb64);
-      for (i <- 0 to 18000000) {
-        sb.append(' ');
-      }
+      val payload = functionb64 + (" " * 18000000)
       val (initCode, _) =
-        c.init(initPayload(sb.toString(), "Apache.OpenWhisk.Tests.Dotnet::Apache.OpenWhisk.Tests.Dotnet.Error::Main"))
+        c.init(initPayload(payload, "Apache.OpenWhisk.Tests.Dotnet::Apache.OpenWhisk.Tests.Dotnet.Error::Main"))
       initCode should be(200)
     }
   }

--- a/tests/src/test/scala/actionContainers/DotNet3_1ActionContainerTests_2_2.scala
+++ b/tests/src/test/scala/actionContainers/DotNet3_1ActionContainerTests_2_2.scala
@@ -23,7 +23,6 @@ import common.WskActorSystem
 import spray.json._
 import actionContainers.ActionContainer.withContainer
 import java.nio.file.Paths
-import java.lang.StringBuilder
 
 @RunWith(classOf[JUnitRunner])
 class DotNet3_1ActionContainerTests_2_2 extends BasicActionRunnerTests with WskActorSystem {
@@ -103,13 +102,9 @@ class DotNet3_1ActionContainerTests_2_2 extends BasicActionRunnerTests with WskA
 
   it should "support a large payload" in {
     val (out, err) = withActionContainer() { c =>
-      val sb = new StringBuilder(18000000 + functionb64.length());
-      sb.append(functionb64);
-      for (i <- 0 to 18000000) {
-        sb.append(' ');
-      }
+      val payload = functionb64 + (" " * 18000000)
       val (initCode, _) =
-        c.init(initPayload(sb.toString(), "Apache.OpenWhisk.Tests.Dotnet::Apache.OpenWhisk.Tests.Dotnet.Error::Main"))
+        c.init(initPayload(payload, "Apache.OpenWhisk.Tests.Dotnet::Apache.OpenWhisk.Tests.Dotnet.Error::Main"))
       initCode should be(200)
     }
   }

--- a/tests/src/test/scala/actionContainers/DotNet3_1ActionContainerTests_2_2.scala
+++ b/tests/src/test/scala/actionContainers/DotNet3_1ActionContainerTests_2_2.scala
@@ -23,6 +23,7 @@ import common.WskActorSystem
 import spray.json._
 import actionContainers.ActionContainer.withContainer
 import java.nio.file.Paths
+import java.lang.StringBuilder
 
 @RunWith(classOf[JUnitRunner])
 class DotNet3_1ActionContainerTests_2_2 extends BasicActionRunnerTests with WskActorSystem {
@@ -98,6 +99,19 @@ class DotNet3_1ActionContainerTests_2_2 extends BasicActionRunnerTests with WskA
       case (o, e) =>
         (o + e).toLowerCase should include("exception")
     })
+  }
+
+  it should "support a large payload" in {
+    val (out, err) = withActionContainer() { c =>
+      val sb = new StringBuilder(18000000 + functionb64.length());
+      sb.append(functionb64);
+      for (i <- 0 to 18000000) {
+        sb.append(' ');
+      }
+      val (initCode, _) =
+        c.init(initPayload(sb.toString(), "Apache.OpenWhisk.Tests.Dotnet::Apache.OpenWhisk.Tests.Dotnet.Error::Main"))
+      initCode should be(200)
+    }
   }
 
   it should "support application errors" in {


### PR DESCRIPTION
I was trying to create an action with a 30mb+ zip. Unfortunately this resulted into an BadHttpRequestException because the request body was too large. 

Therefore Ive increased the MaxRequestBodySize so uploading zip files that are larger than the default limit is possible. 