### PR TITLE
Static methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.vs/
 .idea
 *.iml
 *~

--- a/core/dotnet3.1/QUICKSTART.md
+++ b/core/dotnet3.1/QUICKSTART.md
@@ -22,7 +22,9 @@
 A .NET Core action is a .NET Core class library with a method called `Main` that has the exact signature as follows:
 
 ```csharp
-public Newtonsoft.Json.Linq.JObject Main(Newtonsoft.Json.Linq.JObject);
+using Newtonsoft.Json.Linq;
+
+public static JObject Main(JObject);
 ```
 
 In order to compile, test and archive .NET Core projects, you must have the [.NET Core SDK](https://www.microsoft.com/net/download) installed locally and the environment variable `DOTNET_HOME` set to the location where the `dotnet` executable can be found.
@@ -50,7 +52,7 @@ namespace Apache.OpenWhisk.Example.Dotnet
 {
     public class Hello
     {
-        public JObject Main(JObject args)
+        public static JObject Main(JObject args)
         {
             string name = "stranger";
             if (args.ContainsKey("name")) {

--- a/core/dotnet3.1/proxy/Apache.OpenWhisk.Runtime.Common/Init.cs
+++ b/core/dotnet3.1/proxy/Apache.OpenWhisk.Runtime.Common/Init.cs
@@ -32,7 +32,6 @@ namespace Apache.OpenWhisk.Runtime.Common
         public bool Initialized { get; private set; }
         private Type Type { get; set; }
         private MethodInfo Method { get; set; }
-        private ConstructorInfo Constructor { get; set; }
         private bool AwaitableMethod { get; set; }
 
         public Init()
@@ -40,7 +39,6 @@ namespace Apache.OpenWhisk.Runtime.Common
             Initialized = false;
             Type = null;
             Method = null;
-            Constructor = null;
         }
 
         public async Task<Run> HandleRequest(HttpContext httpContext)
@@ -52,7 +50,7 @@ namespace Apache.OpenWhisk.Runtime.Common
                 {
                     await httpContext.Response.WriteError("Cannot initialize the action more than once.");
                     Console.Error.WriteLine("Cannot initialize the action more than once.");
-                    return (new Run(Type, Method, Constructor, AwaitableMethod));
+                    return (new Run(Type, Method, AwaitableMethod));
                 }
 
                 string body = await new StreamReader(httpContext.Request.Body).ReadToEndAsync();
@@ -128,7 +126,6 @@ namespace Apache.OpenWhisk.Runtime.Common
                         return (null);
                     }
                     Method = Type.GetMethod(mainParts[2]);
-                    Constructor = Type.GetConstructor(Type.EmptyTypes);
                 }
                 catch (Exception ex)
                 {
@@ -147,17 +144,11 @@ namespace Apache.OpenWhisk.Runtime.Common
                     return (null);
                 }
 
-                if (Constructor == null)
-                {
-                    await httpContext.Response.WriteError($"Unable to locate appropriate constructor for (\"{mainParts[1]}\").");
-                    return (null);
-                }
-
                 Initialized = true;
 
                 AwaitableMethod = (Method.ReturnType.GetMethod(nameof(Task.GetAwaiter)) != null);
 
-                return (new Run(Type, Method, Constructor, AwaitableMethod));
+                return (new Run(Type, Method, AwaitableMethod));
             }
             catch (Exception ex)
             {

--- a/core/dotnet3.1/proxy/Apache.OpenWhisk.Runtime.Common/Run.cs
+++ b/core/dotnet3.1/proxy/Apache.OpenWhisk.Runtime.Common/Run.cs
@@ -93,7 +93,7 @@ namespace Apache.OpenWhisk.Runtime.Common
                         return;
                     }
 
-                    await httpContext.Response.WriteResponse( 200, output.ToString());
+                    await httpContext.Response.WriteResponse(200, output.ToString());
                 }
                 catch (Exception ex)
                 {

--- a/core/dotnet3.1/proxy/Apache.OpenWhisk.Runtime.Common/Run.cs
+++ b/core/dotnet3.1/proxy/Apache.OpenWhisk.Runtime.Common/Run.cs
@@ -28,20 +28,18 @@ namespace Apache.OpenWhisk.Runtime.Common
     {
         private readonly Type _type;
         private readonly MethodInfo _method;
-        private readonly ConstructorInfo _constructor;
         private readonly bool _awaitableMethod;
 
-        public Run(Type type, MethodInfo method, ConstructorInfo constructor, bool awaitableMethod)
+        public Run(Type type, MethodInfo method, bool awaitableMethod)
         {
             _type = type;
             _method = method;
-            _constructor = constructor;
             _awaitableMethod = awaitableMethod;
         }
 
         public async Task HandleRequest(HttpContext httpContext)
         {
-            if (_type == null || _method == null || _constructor == null)
+            if (_type == null || _method == null)
             {
                 await httpContext.Response.WriteError("Cannot invoke an uninitialized action.");
                 return;
@@ -77,17 +75,15 @@ namespace Apache.OpenWhisk.Runtime.Common
                     }
                 }
 
-                object owObject = _constructor.Invoke(new object[] { });
-
                 try
                 {
                     JObject output;
                     
                     if(_awaitableMethod) {
-                        output = (JObject) await (dynamic) _method.Invoke(owObject, new object[] {valObject});
+                        output = (JObject) await (dynamic) _method.Invoke(null, new object[] {valObject});
                     }
                     else {
-                        output = (JObject) _method.Invoke(owObject, new object[] {valObject});
+                        output = (JObject) _method.Invoke(null, new object[] {valObject});
                     }
 
                     if (output == null)
@@ -97,7 +93,7 @@ namespace Apache.OpenWhisk.Runtime.Common
                         return;
                     }
 
-                    await httpContext.Response.WriteResponse(200, output.ToString());
+                    await httpContext.Response.WriteResponse( 200, output.ToString());
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Obviously this change is not backward compatible but...

- Static methods are little a bit faster
- No need to create to call `object owObject = _constructor.Invoke(new object[] { });` making it also faster
- By definition static methods are stateless what fits FaaS better