### PR TITLE
Upgrade dotnet sdk packages (removed 2.2 references)

### DIFF
--- a/core/dotnet3.1/proxy/Apache.OpenWhisk.Runtime.Common/Apache.OpenWhisk.Runtime.Common.csproj
+++ b/core/dotnet3.1/proxy/Apache.OpenWhisk.Runtime.Common/Apache.OpenWhisk.Runtime.Common.csproj
@@ -21,14 +21,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore">
-        <Version>2.2.0</Version>
-      </PackageReference>
-      <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel">
-        <Version>2.2.0</Version>
-      </PackageReference>
+      <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+  
+    <ItemGroup>
       <PackageReference Include="Newtonsoft.Json">
-        <Version>12.0.2</Version>
+        <Version>12.0.3</Version>
       </PackageReference>
     </ItemGroup>
 

--- a/core/dotnet3.1/proxy/Apache.OpenWhisk.Runtime.Common/Startup.cs
+++ b/core/dotnet3.1/proxy/Apache.OpenWhisk.Runtime.Common/Startup.cs
@@ -16,11 +16,8 @@
  */
 
 using System;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace Apache.OpenWhisk.Runtime.Common
 {


### PR DESCRIPTION
The project file is still directly referencing Dotnet core 2.2 packages. Due to this, some packages targeting the 3.1 framework (such as Microsoft.Extensions.Logging.Abstractions) are not working properly.

This pull request fixes this issue.