### PR TITLE
change 3.1 runtime to no longer require user functions to use Newtonsoft.Json library

### DIFF
--- a/core/dotnet3.1/build_runtime.sh
+++ b/core/dotnet3.1/build_runtime.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+IMAGE="mwelke/openwhisk-runtime-dotnet-v3.1-nojson:1"
+
+docker build -t $IMAGE .
+docker push $IMAGE

--- a/core/dotnet3.1/proxy/Apache.OpenWhisk.Runtime.Common/Apache.OpenWhisk.Runtime.Common.csproj
+++ b/core/dotnet3.1/proxy/Apache.OpenWhisk.Runtime.Common/Apache.OpenWhisk.Runtime.Common.csproj
@@ -23,11 +23,9 @@
     <ItemGroup>
       <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
-  
+
     <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json">
-        <Version>12.0.3</Version>
-      </PackageReference>
+      <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     </ItemGroup>
 
 </Project>

--- a/core/dotnet3.1/proxy/Apache.OpenWhisk.Runtime.Common/Init.cs
+++ b/core/dotnet3.1/proxy/Apache.OpenWhisk.Runtime.Common/Init.cs
@@ -125,7 +125,8 @@ namespace Apache.OpenWhisk.Runtime.Common
                     if (message["env"] != null && message["env"].HasValues)
                     {
                         Dictionary<string, string> dictEnv = message["env"].ToObject<Dictionary<string, string>>();
-                        foreach (KeyValuePair<string, string> entry in dictEnv) {
+                        foreach (KeyValuePair<string, string> entry in dictEnv)
+                        {
                             // See https://docs.microsoft.com/en-us/dotnet/api/system.environment.setenvironmentvariable
                             // If entry.Value is null or the empty string, the variable is not set
                             Environment.SetEnvironmentVariable(entry.Key, entry.Value);


### PR DESCRIPTION
This PR is for demonstration purposes only related to https://github.com/apache/openwhisk-runtime-dotnet/issues/51. We can't make this kind of change to an existing runtime without breaking existing actions for the runtime. But it's easier to show the change this way by diffing it with an existing runtime (3.1 used here), since not much actually changes. This changed version of the runtime only supports non-awaitable Main methods in the action. Supporting await wasn't needed to demonstrate the change.