### PR TITLE
Use aspnet as runtime

### DIFF
--- a/core/net6.0/Dockerfile
+++ b/core/net6.0/Dockerfile
@@ -28,7 +28,7 @@ COPY proxy/Apache.OpenWhisk.Runtime.Dotnet.Minimal/. ./Apache.OpenWhisk.Runtime.
 WORKDIR /app/Apache.OpenWhisk.Runtime.Dotnet.Minimal
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0-alpine AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS runtime
 
 # Get the latest security fixes in case the base image does not contain them already.
 RUN apk update \

--- a/core/net6.0/Dockerfile
+++ b/core/net6.0/Dockerfile
@@ -28,7 +28,7 @@ COPY proxy/Apache.OpenWhisk.Runtime.Dotnet.Minimal/. ./Apache.OpenWhisk.Runtime.
 WORKDIR /app/Apache.OpenWhisk.Runtime.Dotnet.Minimal
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS runtime
+FROM mcr.microsoft.com/dotnet/runtime:6.0-alpine AS runtime
 
 # Get the latest security fixes in case the base image does not contain them already.
 RUN apk update \

--- a/core/net6.0/Dockerfile
+++ b/core/net6.0/Dockerfile
@@ -26,9 +26,9 @@ RUN dotnet restore
 COPY proxy/Apache.OpenWhisk.Runtime.Common/. ./Apache.OpenWhisk.Runtime.Common/
 COPY proxy/Apache.OpenWhisk.Runtime.Dotnet.Minimal/. ./Apache.OpenWhisk.Runtime.Dotnet.Minimal/
 WORKDIR /app/Apache.OpenWhisk.Runtime.Dotnet.Minimal
-RUN dotnet publish -c Release -r linux-musl-x64 -o out
+RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0-alpine AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS runtime
 
 # Get the latest security fixes in case the base image does not contain them already.
 RUN apk update \
@@ -37,6 +37,6 @@ RUN apk update \
 
 WORKDIR /app
 COPY --from=build /app/Apache.OpenWhisk.Runtime.Dotnet.Minimal/out ./
-ENV ASPNETCORE_URLS http://+:8080
+ENV ASPNETCORE_URLS=http://+:8080
 EXPOSE 8080/tcp
 ENTRYPOINT ["dotnet", "Apache.OpenWhisk.Runtime.Dotnet.Minimal.dll"]


### PR DESCRIPTION
This is a fix for #87 

While building the image I noticed that the flag `-r linux-musl-x64` actually bundles all the shared libraries along the app. There is already an image provided by microsoft that contains all these libraries so this is redundant and is platform specific.

The images used as base are actually manifest lists and the correct image will be pulled depending on the architecture of the machine building it. I am relying on the pipeline to test the changes, since I don't have access to a x64 machine.

This change will decrease the image size by about 40% and enable building this on x64 and arm64.